### PR TITLE
fix bug SassError in bootstrap

### DIFF
--- a/src/styles/bootstrap/_variables.scss
+++ b/src/styles/bootstrap/_variables.scss
@@ -1,5 +1,5 @@
 // import font
-@import url(http://fonts.googleapis.com/css?family=Open + Sans:300italic, 400italic, 600italic, 400, 300, 600);
+@import url(http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,400,300,600);
 // Variables
 //
 // Variables should follow the `$component-state-property-size` formula for

--- a/src/styles/bootstrap/mixins/_image.scss
+++ b/src/styles/bootstrap/mixins/_image.scss
@@ -26,7 +26,7 @@
     // but doesn't convert dppx=>dpi.
     // There's no such thing as unprefixed min-device-pixel-ratio since it's nonstandard.
     // Compatibility info: https://caniuse.com/#feat=css-media-resolution
-    @media only screen and (min-resolution: 192dpi),
+    @media only screen and (min-resolution: 192dpi) {
         // IE9-11 don't support dppx only screen and (min-resolution: 2dppx) {
         // Standardized
         background-image: url($file-2x);


### PR DESCRIPTION
I got two SassError when I tried to build

```
ERROR in ./src/styles/app.scss (./node_modules/@angular-devkit/build-angular/src/angular-cli-files/plugins/raw-css-loader.js!./node_modules/postcss-loader/src??embedded!./node_modules/sass-loader/dist/cjs.js??ref--13-3!./src/styles/app.scss)
Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: expected ")".
  ╷
2 │ @import url(http://fonts.googleapis.com/css?family=Open + Sans:300italic, 400italic, 600italic, 400, 300, 600);
  │                 ^
  ╵
  src/styles/bootstrap/_variables.scss 2:17  @import
  src/styles/bootstrap/bootstrap.scss 9:9    @import
  /Users/dontaire/Repository/SB-Admin-BS4-Angular-8/src/styles/app.scss 2:9    
```

```
ERROR in ./src/styles/app.scss (./node_modules/@angular-devkit/build-angular/src/angular-cli-files/plugins/raw-css-loader.js!./node_modules/postcss-loader/src??embedded!./node_modules/sass-loader/dist/cjs.js??ref--13-3!./src/styles/app.scss)
Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: expected "{".
   ╷
32 │         background-image: url($file-2x);
   │                         ^
   ╵
  src/styles/bootstrap/mixins/_image.scss 32:25  @import
  src/styles/bootstrap/_mixins.scss 8:9          @import
  src/styles/bootstrap/bootstrap.scss 10:9       @import
  /Users/dontaire/Repository/SB-Admin-BS4-Angular-8/src/styles/app.scss 2:9   
```
